### PR TITLE
Parses and reads the hackmd main pad to display in the wiki.

### DIFF
--- a/content/.vuepress/config.js
+++ b/content/.vuepress/config.js
@@ -59,6 +59,7 @@ module.exports = {
                         '/wiki/Get-Involved',
                         '/wiki/Code-of-Conduct',
                         '/wiki/Contact',
+                        '/wiki/Meetings',
                         '/wiki/License-Policy',
                         '/wiki/Other-Projects',
                         '/wiki/Frequently-Asked-Questions',

--- a/content/wiki/Contact.md
+++ b/content/wiki/Contact.md
@@ -33,11 +33,14 @@ Good for player questions or to see what we are up to.
 
 ## Meetings
 
+Meetings take place regularely every 2 weeks (even calendar week numbers - 2,4,6 etc).
+
 We meet on [Mumble](https://github.com/mumble-voip/mumble) on "nooblounge.net", port 64738.
 
-Meetings take place when necessary and will be announced in the IRC channel.
+Meetings take place when necessary and will be announced in the IRC channel (Riot/Matrix) and Telegram.
 
 In advance to every meeting a pad will be created with topics to be discussed.
 
-_Protocols of old or upcoming meetings:_ 
-* Can be found here: https://hackmd.io/CYFhFYCYCMGYEYC0A2e9yJAYwKYENE4AOWRPHCABiz2AE5hLIg==?both
+<div class="flex justify-end">
+   <router-link to="./Meetings.html" class="button my-4">List of Meetings</router-link>
+</div>

--- a/content/wiki/Contact.md
+++ b/content/wiki/Contact.md
@@ -33,14 +33,8 @@ Good for player questions or to see what we are up to.
 
 ## Meetings
 
-Meetings take place regularely every 2 weeks (even calendar week numbers - 2,4,6 etc).
-
-We meet on [Mumble](https://github.com/mumble-voip/mumble) on "nooblounge.net", port 64738.
-
-Meetings take place when necessary and will be announced in the IRC channel (Riot/Matrix) and Telegram.
-
-In advance to every meeting a pad will be created with topics to be discussed.
+We meet bi-weekly to discuss current progress and blocking points and how we can support each other. Newcomers are also invited to let us know how they want to get involved.
 
 <div class="flex justify-end">
-   <router-link to="./Meetings.html" class="button my-4">List of Meetings</router-link>
+   <router-link to="./Meetings.html" class="button my-4">Learn more</router-link>
 </div>

--- a/content/wiki/Meetings.md
+++ b/content/wiki/Meetings.md
@@ -1,29 +1,57 @@
 # Meetings
 
-They are [maintained on HackMD](https://hackmd.io/CYFhFYCYCMGYEYC0A2e9yJAYwKYENE4AOWRPHCABiz2AE5hLIg==?both)
+Meetings take place regularely every 2 weeks (even calendar week numbers - 2,4,6 etc) usually at 21:00 CET.
 
-<pre><code>
-{{meetings}}
-</code></pre>
+We meet on [Mumble](https://github.com/mumble-voip/mumble) on "nooblounge.net", port 64738.
+
+Meetings take place to discuss current progress and new problems. Meetings will be announced in the IRC channel (Riot/Matrix) and Telegram.
+
+In advance to every meeting a team member will create a pad, with topics to be discussed.
+
+## How to prepare a meeting?
+
+You can use [this template](https://hackmd.io/kePoI6e2QuGQF__tZUJvkw) to prepare a meeting. 
+Once filled in, <a :href="`https://hackmd.io/${hackpad}`">add it to the list of the meetings on HackMD.</a>
+The note will then automatically appear below.
+
+## History
+
+<div class="flex flex-wrap">
+    <div v-for="(notes, year) in meetings" class="w-1/2 md:w-1/3 xl:w-1/5">
+        <h3>{{year}}</h3>
+        <ul>
+            <li v-for="note in notes">
+                <a :href="note.link">
+                    {{note.name}}
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>
+
 <script>
-const HACKPAD = '1EUrMWEVTOqzg65FDK2dAg'
 
 export default {
     data: () => ({
         meetings: [],
+        hackpad: '1EUrMWEVTOqzg65FDK2dAg'
     }),
     async mounted() {
-        let response = await fetch(`https://hackmd.io/${HACKPAD}/download`)
+        let response = await fetch(`https://hackmd.io/${this.hackpad}/download`)
         let markdown = await response.text()
         markdown = /(?:## Meetings)([\W\n\w]*?)(?:##)/gm
             .exec(markdown)[1]
+            // turn lines into array items
             .split('\n')
+            // remove empty lines
             .filter(String)
+            // turn array of lines into a tree of year/notes pairings
             .reduce((acc, cur, index, array) => {
                 let indent = cur.match(/\s+/)[0].length
                 let year = cur.match(/\d{4}/g)[0]
                 if (!acc[year]) acc[year] = []
-                if (indent > 1) acc[year].push(cur)
+                let [match, name, link] = cur.match(/(?:.*?)\[(.*?)\]\((.*?)\)/) || []
+                if (indent > 1) acc[year].push({name, link})
                 return acc
             }, {})
         this.meetings = markdown

--- a/content/wiki/Meetings.md
+++ b/content/wiki/Meetings.md
@@ -1,0 +1,32 @@
+# Meetings
+
+They are [maintained on HackMD](https://hackmd.io/CYFhFYCYCMGYEYC0A2e9yJAYwKYENE4AOWRPHCABiz2AE5hLIg==?both)
+
+<pre><code>
+{{meetings}}
+</code></pre>
+<script>
+const HACKPAD = '1EUrMWEVTOqzg65FDK2dAg'
+
+export default {
+    data: () => ({
+        meetings: [],
+    }),
+    async mounted() {
+        let response = await fetch(`https://hackmd.io/${HACKPAD}/download`)
+        let markdown = await response.text()
+        markdown = /(?:## Meetings)([\W\n\w]*?)(?:##)/gm
+            .exec(markdown)[1]
+            .split('\n')
+            .filter(String)
+            .reduce((acc, cur, index, array) => {
+                let indent = cur.match(/\s+/)[0].length
+                let year = cur.match(/\d{4}/g)[0]
+                if (!acc[year]) acc[year] = []
+                if (indent > 1) acc[year].push(cur)
+                return acc
+            }, {})
+        this.meetings = markdown
+    }
+}
+</script>


### PR DESCRIPTION
Granted, we don't change the structure of the hackpad. 
The following regex are used to read the crucial parts. That also means that they also depend on the structure of the document.

### List of meetings - `/(?:## Meetings)([\W\n\w]*?)(?:##)/gm`
Matches main part of the document with non capturing groups between the end of the heading and the beginning of the next heading.

### Indent length - `/\s+/`
Used to define how deep the structure is (e.g. 1 indent level - first level, 5 indent levels - second level)

### Year number - `/\d{4}/g`
This also just works with the current structure.
Every first level item has the year as name.
Every second level item defines a link to the post with the exact date as link name with full year (4 digits).

### Link and text - `/(?:.*?)\[(.*?)\]\((.*?)\)/`
This goes along with the structure of a typical markdown link: `[text](link)`

If you find better regular expressions, to make it less dependent on a structure - please let me know!
I searched for libraries that would parse markdown, but found no small ones. I wouldn't want to impose a 40kb library just for parsing the part of the markdown of hackmd for a list of meetings.

Thanks for reviewing!